### PR TITLE
Add Makefile for common project commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+SHELL := /bin/bash
+
+UI_DIR := ui
+
+.PHONY: install build run test lint preview clean
+
+install:
+	@npm --prefix $(UI_DIR) install
+
+build:
+	@npm --prefix $(UI_DIR) run build
+
+run:
+	@npm --prefix $(UI_DIR) run dev
+
+test:
+	@npm --prefix $(UI_DIR) test
+
+lint:
+	@npm --prefix $(UI_DIR) run lint
+
+preview:
+	@npm --prefix $(UI_DIR) run preview
+
+clean:
+	rm -rf $(UI_DIR)/node_modules $(UI_DIR)/dist
+

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/


### PR DESCRIPTION
## Summary
- add Makefile with targets for install, build, run, test, lint, preview, and clean
- update Vite config to load defineConfig from vitest/config so tests and build work

## Testing
- `make install`
- `make lint`
- `make test`
- `make build`
- `timeout 3 make run`


------
https://chatgpt.com/codex/tasks/task_e_68af41b49eec8321845d0fee56ff5fd2